### PR TITLE
avoid nil package resource name for pkg_php_mbstring

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -57,8 +57,12 @@ package pkg_php_imap do
   action :install
 end
 
-package pkg_php_mbstring do
+# pkg_php_mbstring may be nil; we thus cannot use the 
+# variable value as the package resource name but have
+# to specify the package name as an explicit attribute
+package "optional_php-mbstring" do
   not_if do pkg_php_mbstring.nil? end
+  package_name pkg_php_mbstring
   action :install
 end
 


### PR DESCRIPTION
As reported in issue #2, the nil value in `pkg_php_mbstring` makes postfixadmin-cookbook's default recipe fail for me with an error message that package resource names must not be nil.

This patch always assigns a non-nil name to the package resource and specifies the package name via the `package_name` resource attribute. This way the `not_if` guard becomes effective.

Regards
Christoph
