### PR TITLE
include specific helpers instead of database::#{type}

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -42,6 +42,7 @@ depends 'nginx', '~> 2.7'
 depends 'php', '~> 1.5'
 depends 'php-fpm', '>= 0.7'
 depends 'postgresql', '~> 3.4'
+depends 'mysql2_chef_gem', '~> 1.0'
 depends 'ssl_certificate', '~> 1.1'
 depends 'yum-epel', '~> 0.5'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -66,10 +66,13 @@ chef_gem 'sequel'
 
 if %w(localhost 127.0.0.1).include?(node['postfixadmin']['database']['host'])
   include_recipe "postfixadmin::#{db_type}"
-  include_recipe "database::#{db_type}"
 
   case db_type
   when 'mysql'
+
+    mysql2_chef_gem 'default' do
+      action :install
+    end
 
     mysql_connection_info = {
       host: node['postfixadmin']['database']['host'],
@@ -94,6 +97,8 @@ if %w(localhost 127.0.0.1).include?(node['postfixadmin']['database']['host'])
     end
 
   when 'postgresql'
+
+    include_recipe 'postgresql::ruby'
 
     postgresql_connection_info = {
       host: 'localhost',

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -70,8 +70,12 @@ describe 'postfixadmin::default' do
     expect(chef_run).to include_recipe('postfixadmin::mysql')
   end
 
-  it 'includes database::mysql recipe' do
-    expect(chef_run).to include_recipe('database::mysql')
+  it 'does not include the database::mysql recipe' do
+    expect(chef_run).to_not include_recipe('database::mysql')
+  end
+
+  it 'installs the mysql2_chef gem' do
+    expect(chef_run).to install_mysql2_chef_gem('default')
   end
 
   it 'creates mysql database' do
@@ -193,8 +197,12 @@ describe 'postfixadmin::default' do
       expect(chef_run).to include_recipe('postfixadmin::postgresql')
     end
 
-    it 'includes database::postgresql recipe' do
-      expect(chef_run).to include_recipe('database::postgresql')
+    it 'does not include the database::postgresql recipe' do
+      expect(chef_run).to_not include_recipe('database::postgresql')
+    end
+
+    it 'includes postgresql::ruby recipe' do
+      expect(chef_run).to include_recipe('postgresql::ruby')
     end
 
     it 'creates postgresql database' do


### PR DESCRIPTION
This is because community cookbook database removed
database::mysql in v4.0.2, and database::postgresql
is a mere include of postgresql::ruby anyways.

In case of mysql, we now include mysql2_chef_gem
as directed by the database cookbook.
For postsgresql we just include postgresql::ruby
ourselves, since that may be removed next…